### PR TITLE
Fix for #1 Clean clone build fails with OOM

### DIFF
--- a/lexer-parser-walker-composed/pom.xml
+++ b/lexer-parser-walker-composed/pom.xml
@@ -52,6 +52,7 @@
 				<configuration>
 					<executable>java</executable>
 					<arguments>
+						<argument>-Xmx2g</argument>
 						<argument>-classpath</argument>
 						<classpath/>
 						<argument>org.antlr.Tool</argument>

--- a/lexer-parser-walker/pom.xml
+++ b/lexer-parser-walker/pom.xml
@@ -52,6 +52,7 @@
 				<configuration>
 					<executable>java</executable>
 					<arguments>
+						<argument>-Xmx2g</argument>
 						<argument>-classpath</argument>
 						<classpath/>
 						<argument>org.antlr.Tool</argument>

--- a/lexer-parser/pom.xml
+++ b/lexer-parser/pom.xml
@@ -52,6 +52,7 @@
 				<configuration>
 					<executable>java</executable>
 					<arguments>
+						<argument>-Xmx2g</argument>
 						<argument>-classpath</argument>
 						<classpath/>
 						<argument>org.antlr.Tool</argument>


### PR DESCRIPTION
Simply setting up the memory expectations for `exec-maven-plugin`
