### PR TITLE
parse explain in seq_of_statements

### DIFF
--- a/parsers/PLSQLParser.g
+++ b/parsers/PLSQLParser.g
@@ -1110,6 +1110,7 @@ backtrack=true;
     |    return_statement
     |    case_statement[true]
     |    sql_statement
+	|	 explain_statement
     |    function_call
     ;
 


### PR DESCRIPTION
PLSQLParser.g override PLSQL_DMLParser.g's seq_of_statements, but lost explain_statement. 
See my patch. :)
